### PR TITLE
Update README.md with correct image location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](https://github.com/freebroccolo/docker-haskell/blob/master/logo.png?raw=true)
+![image](https://github.com/haskell/docker-haskell/blob/master/logo.png?raw=true)
 
 ---
 


### PR DESCRIPTION
I see the repo just moved.  I suppose this link should also move.

There's more references to the old repo in https://github.com/docker-library/docs/blob/master/haskell/content.md .  Should I also file a PR against docker-library/docs, or is that already on your list?