### PR TITLE
Bump to GHC 8.8.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [8.6.5, 8.8.1]
+        ghc: [8.6.5, 8.8.2]
         include:
           - ghc: 8.6.5
             ghc_minor: 8.6
-          - ghc: 8.8.1
+          - ghc: 8.8.2
             ghc_minor: 8.8
     steps:
     - uses: actions/checkout@v2

--- a/8.8/Dockerfile
+++ b/8.8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GHC=8.8.1
+ARG GHC=8.8.2
 ARG STACK=2.1.3
 ARG CABAL_INSTALL=3.0
 


### PR DESCRIPTION
Note: I recently parameterized the Dockerfiles and added GitHub Actions for a basic smoke test of the build.

cc @hvr :heart:

This does not address `aarch64` support, but that is the next thing to look at once this ships.