### PR TITLE
Update from debian stretch (9) to buster (10) for ghc 8.6, 8.8

### DIFF
--- a/8.6/Dockerfile
+++ b/8.6/Dockerfile
@@ -1,15 +1,15 @@
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GHC=8.6.5
-ARG STACK=1.9.3
-ARG CABAL_INSTALL=2.4
+ARG STACK=2.1.3
+ARG CABAL_INSTALL=3.0
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574 && \
-    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
+    echo 'deb http://downloads.haskell.org/debian buster main' > /etc/apt/sources.list.d/ghc.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
@@ -27,7 +27,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 427CB69AAC9D00F2A43
     rm -rf /var/lib/apt/lists/*
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 2C6A674E85EE3FB896AFC9B965101FF31C5C154D && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
     gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \

--- a/8.8/Dockerfile
+++ b/8.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
@@ -9,7 +9,7 @@ ARG STACK=2.1.3
 ARG CABAL_INSTALL=3.0
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574 && \
-    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
+    echo 'deb http://downloads.haskell.org/debian buster main' > /etc/apt/sources.list.d/ghc.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
@@ -27,7 +27,6 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 427CB69AAC9D00F2A43
     rm -rf /var/lib/apt/lists/*
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 2C6A674E85EE3FB896AFC9B965101FF31C5C154D && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \


### PR DESCRIPTION
Closes #8

- Updated 8.6, 8.8 to buster.
- Updated 8.6 to stack 2.1.3
- Updated 8.6 to use cabal 3.0
- gpg key `C5705533DA4F78D8664B5DC0575159689BEFB442` is not needed in buster.. apparently.. so I deleted it.

https://downloads.haskell.org/debian/ currently only has cabal version 3.0 in buster, so I thought updating to it for 8.6 was probably worth it (and with cabal 3.0 I think latest stack should work better). Alternatively 8.6 could be left as is on stretch. For this reason I have not touched 8.2, 8.4 which currently use old versions of cabal.

This is something of breaking change if people naively pull the new version. Might be worth some kind of `8.8-buster` tag, or `8.8-stretch`. This appears to be handled manually? Or is this a change I can make in my PR?