### PR TITLE
Move the stack args to just before they are needed

### DIFF
--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ARG GHC=8.10.4
 ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
 ARG CABAL_INSTALL=3.4
-ARG STACK=2.7.1
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
@@ -33,6 +30,10 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
         xz-utils \
         zlib1g-dev && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+
+ARG STACK=2.7.1
+ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys ${STACK_KEY} && \

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -3,7 +3,20 @@ FROM debian:buster
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        g++ \
+        git \
+        gnupg \
+        libsqlite3-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        openssh-client \
+        xz-utils \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GHC=8.10.4
@@ -18,17 +31,7 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
-        curl \
-        g++ \
-        ghc-${GHC} \
-        git \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        ghc-${GHC} && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
 
 ARG STACK=2.7.1

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ARG GHC=8.10.4
 ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
 ARG CABAL_INSTALL=3.4
-ARG STACK=2.7.1
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
@@ -33,6 +30,10 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
         xz-utils \
         zlib1g-dev && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+
+ARG STACK=2.7.1
+ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys ${STACK_KEY} && \

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -3,7 +3,20 @@ FROM debian:stretch
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        g++ \
+        git \
+        gnupg \
+        libsqlite3-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        openssh-client \
+        xz-utils \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GHC=8.10.4
@@ -18,17 +31,7 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
-        curl \
-        g++ \
-        ghc-${GHC} \
-        git \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        ghc-${GHC} && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
 
 ARG STACK=2.7.1

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ARG GHC=9.0.1
 ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
 ARG CABAL_INSTALL=3.4
-ARG STACK=2.7.1
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
@@ -33,6 +30,10 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
         xz-utils \
         zlib1g-dev && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+
+ARG STACK=2.7.1
+ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys ${STACK_KEY} && \

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -3,7 +3,20 @@ FROM debian:buster
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        g++ \
+        git \
+        gnupg \
+        libsqlite3-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        openssh-client \
+        xz-utils \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GHC=9.0.1
@@ -18,17 +31,7 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
-        curl \
-        g++ \
-        ghc-${GHC} \
-        git \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        ghc-${GHC} && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
 
 ARG STACK=2.7.1

--- a/9.0/stretch/Dockerfile
+++ b/9.0/stretch/Dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ARG GHC=9.0.1
 ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
 ARG CABAL_INSTALL=3.4
-ARG STACK=2.7.1
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
@@ -33,6 +30,10 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
         xz-utils \
         zlib1g-dev && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+
+ARG STACK=2.7.1
+ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys ${STACK_KEY} && \

--- a/9.0/stretch/Dockerfile
+++ b/9.0/stretch/Dockerfile
@@ -3,7 +3,20 @@ FROM debian:stretch
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        g++ \
+        git \
+        gnupg \
+        libsqlite3-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        openssh-client \
+        xz-utils \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GHC=9.0.1
@@ -18,17 +31,7 @@ RUN export GNUPGHOME="$(mktemp -d)" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         cabal-install-${CABAL_INSTALL} \
-        curl \
-        g++ \
-        ghc-${GHC} \
-        git \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        ghc-${GHC} && \
     rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
 
 ARG STACK=2.7.1


### PR DESCRIPTION
This increases layer cacheability so that new stack versions will not invalidate the ghc / cabal install layer. As noted by @yosifkit https://github.com/docker-library/official-images/pull/10140#issuecomment-837364923

You could maximise layer caching further by moving the ghc / stack required packages ie. `g++` to the initial `apt-get install`, which would mean new cabal versions would not invalidate these packages from being installed (or from the user's perspective, the invalidated layers they need to redownload are smaller). My inclination would be to do this change as well, or perhaps the current logical grouping has value? Any thoughts @psftw ?

EDIT: Hmm investigating the failure.. ok seems to have been a flaky gpg issue, or a caching issue. Rerunning fixed it.