### PR TITLE
Switch to ghcup as the installation method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.6', '9.0.1']
+        ghc: ['8.10.7', '9.0.1']
         deb: ['stretch', 'buster']
         include:
-          - ghc: '8.10.6'
+          - ghc: '8.10.7'
             ghc_minor: '8.10'
           - ghc: '9.0.1'
             ghc_minor: '9.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.5', '9.0.1']
+        ghc: ['8.10.6', '9.0.1']
         deb: ['stretch', 'buster']
         include:
-          - ghc: '8.10.5'
+          - ghc: '8.10.6'
             ghc_minor: '8.10'
           - ghc: '9.0.1'
             ghc_minor: '9.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.4', '9.0.1']
+        ghc: ['8.10.5', '9.0.1']
         deb: ['stretch', 'buster']
         include:
-          - ghc: '8.10.4'
+          - ghc: '8.10.5'
             ghc_minor: '8.10'
           - ghc: '9.0.1'
             ghc_minor: '9.0'

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -1,15 +1,56 @@
+FROM debian:buster AS builder
+
+ENV LANG C.UTF-8
+
+# to install ghcup + ghc, cabal and stack
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libffi-dev \
+        libffi6 \
+        libgmp-dev \
+        libgmp10 \
+        libncurses-dev \
+        libncurses5 \
+        libtinfo5 && \
+    rm -rf /var/lib/apt/lists/*
+
+# install ghcup
+ARG GHCUP_VERSION=0.1.16.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
+
+# install cabal
+ARG CABAL_VERSION=3.4.0.0
+RUN ghcup install cabal -i /usr/local/bin $CABAL_VERSION
+
+# install stack
+ARG STACK_VERSION=2.7.3
+RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
+
+# install GHC into /opt/ghc + remove profiling support
+ARG GHC_VERSION=8.10.4
+RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
+  find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
+  find /opt/ghc/lib -name "*_p.a" -type f -delete
+
 FROM debian:buster
 
 ENV LANG C.UTF-8
 
+# common haskell + stack dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dirmngr \
-        g++ \
         git \
-        gnupg \
+        gcc \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
         libsqlite3-dev \
         libtinfo-dev \
         make \
@@ -19,36 +60,18 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GHC=8.10.4
-ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
-ARG CABAL_INSTALL=3.4
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /opt/ghc/bin /opt/ghc/bin
+COPY --from=builder /opt/ghc/lib /opt/ghc/lib
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
-    gpg --batch --armor --export ${DEBIAN_KEY} > /etc/apt/trusted.gpg.d/haskell.org.gpg.asc && \
-    gpgconf --kill all && \
-    echo 'deb http://downloads.haskell.org/debian buster main' > /etc/apt/sources.list.d/ghc.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cabal-install-${CABAL_INSTALL} \
-        ghc-${GHC} && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+# stack should use global ghc
+RUN /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false
 
-ARG STACK=2.7.3
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
+# ensure any user gets GHC on the path
+RUN echo 'export PATH="/opt/ghc/bin:$PATH"' >> /etc/profile.d/ghc_path.sh && \
+	chmod +x /etc/profile.d/ghc_path.sh
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_KEY} && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_RELEASE_KEY} && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
-    gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    /usr/local/bin/stack config set system-ghc --global true && \
-    /usr/local/bin/stack config set install-ghc --global false && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
-
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/${CABAL_INSTALL}/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/bin:$PATH
 
 CMD ["ghci"]

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.6
+ARG GHC_VERSION=8.10.7
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.5
+ARG GHC_VERSION=8.10.6
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.4
+ARG GHC_VERSION=8.10.5
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.6
+ARG GHC_VERSION=8.10.7
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.5
+ARG GHC_VERSION=8.10.6
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -31,7 +31,7 @@ ARG STACK_VERSION=2.7.3
 RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
 
 # install GHC into /opt/ghc + remove profiling support
-ARG GHC_VERSION=8.10.4
+ARG GHC_VERSION=8.10.5
 RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
   find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
   find /opt/ghc/lib -name "*_p.a" -type f -delete

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -1,15 +1,56 @@
+FROM debian:stretch AS builder
+
+ENV LANG C.UTF-8
+
+# to install ghcup + ghc, cabal and stack
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libffi-dev \
+        libffi6 \
+        libgmp-dev \
+        libgmp10 \
+        libncurses-dev \
+        libncurses5 \
+        libtinfo5 && \
+    rm -rf /var/lib/apt/lists/*
+
+# install ghcup
+ARG GHCUP_VERSION=0.1.16.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
+
+# install cabal
+ARG CABAL_VERSION=3.4.0.0
+RUN ghcup install cabal -i /usr/local/bin $CABAL_VERSION
+
+# install stack
+ARG STACK_VERSION=2.7.3
+RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
+
+# install GHC into /opt/ghc + remove profiling support
+ARG GHC_VERSION=8.10.4
+RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
+  find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
+  find /opt/ghc/lib -name "*_p.a" -type f -delete
+
 FROM debian:stretch
 
 ENV LANG C.UTF-8
 
+# common haskell + stack dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dirmngr \
-        g++ \
         git \
-        gnupg \
+        gcc \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
         libsqlite3-dev \
         libtinfo-dev \
         make \
@@ -19,36 +60,18 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GHC=8.10.4
-ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
-ARG CABAL_INSTALL=3.4
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /opt/ghc/bin /opt/ghc/bin
+COPY --from=builder /opt/ghc/lib /opt/ghc/lib
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
-    gpg --batch --armor --export ${DEBIAN_KEY} > /etc/apt/trusted.gpg.d/haskell.org.gpg.asc && \
-    gpgconf --kill all && \
-    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cabal-install-${CABAL_INSTALL} \
-        ghc-${GHC} && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+# stack should use global ghc
+RUN /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false
 
-ARG STACK=2.7.3
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
+# ensure any user gets GHC on the path
+RUN echo 'export PATH="/opt/ghc/bin:$PATH"' >> /etc/profile.d/ghc_path.sh && \
+	chmod +x /etc/profile.d/ghc_path.sh
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_KEY} && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_RELEASE_KEY} && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
-    gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    /usr/local/bin/stack config set system-ghc --global true && \
-    /usr/local/bin/stack config set install-ghc --global false && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
-
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/${CABAL_INSTALL}/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/bin:$PATH
 
 CMD ["ghci"]

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -1,15 +1,56 @@
+FROM debian:buster AS builder
+
+ENV LANG C.UTF-8
+
+# to install ghcup + ghc, cabal and stack
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libffi-dev \
+        libffi6 \
+        libgmp-dev \
+        libgmp10 \
+        libncurses-dev \
+        libncurses5 \
+        libtinfo5 && \
+    rm -rf /var/lib/apt/lists/*
+
+# install ghcup
+ARG GHCUP_VERSION=0.1.16.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
+
+# install cabal
+ARG CABAL_VERSION=3.4.0.0
+RUN ghcup install cabal -i /usr/local/bin $CABAL_VERSION
+
+# install stack
+ARG STACK_VERSION=2.7.3
+RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
+
+# install GHC into /opt/ghc + remove profiling support
+ARG GHC_VERSION=9.0.1
+RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
+  find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
+  find /opt/ghc/lib -name "*_p.a" -type f -delete
+
 FROM debian:buster
 
 ENV LANG C.UTF-8
 
+# common haskell + stack dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dirmngr \
-        g++ \
         git \
-        gnupg \
+        gcc \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
         libsqlite3-dev \
         libtinfo-dev \
         make \
@@ -19,36 +60,18 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GHC=9.0.1
-ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
-ARG CABAL_INSTALL=3.4
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /opt/ghc/bin /opt/ghc/bin
+COPY --from=builder /opt/ghc/lib /opt/ghc/lib
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
-    gpg --batch --armor --export ${DEBIAN_KEY} > /etc/apt/trusted.gpg.d/haskell.org.gpg.asc && \
-    gpgconf --kill all && \
-    echo 'deb http://downloads.haskell.org/debian buster main' > /etc/apt/sources.list.d/ghc.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cabal-install-${CABAL_INSTALL} \
-        ghc-${GHC} && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+# stack should use global ghc
+RUN /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false
 
-ARG STACK=2.7.3
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
+# ensure any user gets GHC on the path
+RUN echo 'export PATH="/opt/ghc/bin:$PATH"' >> /etc/profile.d/ghc_path.sh && \
+	chmod +x /etc/profile.d/ghc_path.sh
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_KEY} && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_RELEASE_KEY} && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
-    gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    /usr/local/bin/stack config set system-ghc --global true && \
-    /usr/local/bin/stack config set install-ghc --global false && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
-
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/${CABAL_INSTALL}/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/bin:$PATH
 
 CMD ["ghci"]

--- a/9.0/stretch/Dockerfile
+++ b/9.0/stretch/Dockerfile
@@ -1,15 +1,18 @@
-FROM debian:stretch
+FROM debian:stretch AS builder
 
 ENV LANG C.UTF-8
 
+# to install ghcup + ghc, cabal and stack
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        dirmngr \
-        g++ \
         git \
-        gnupg \
+        gcc \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
         libsqlite3-dev \
         libtinfo-dev \
         make \
@@ -19,36 +22,59 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GHC=9.0.1
-ARG DEBIAN_KEY=427CB69AAC9D00F2A43CAF1CBA3CBA3FFE22B574
-ARG CABAL_INSTALL=3.4
+# install ghcup
+ARG GHCUP_VERSION=0.1.16.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${DEBIAN_KEY} && \
-    gpg --batch --armor --export ${DEBIAN_KEY} > /etc/apt/trusted.gpg.d/haskell.org.gpg.asc && \
-    gpgconf --kill all && \
-    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
-    apt-get update && \
+# install cabal
+ARG CABAL_VERSION=3.4.0.0
+RUN ghcup install cabal -i /usr/local/bin $CABAL_VERSION
+
+# install stack
+ARG STACK_VERSION=2.7.3
+RUN ghcup install stack -i /usr/local/bin $STACK_VERSION
+
+# install GHC into /opt/ghc + remove profiling support
+ARG GHC_VERSION=9.0.1
+RUN ghcup install ghc -i /opt/ghc $GHC_VERSION && \
+  find /opt/ghc/lib -name "*.p_hi" -type f -delete && \
+  find /opt/ghc/lib -name "*_p.a" -type f -delete
+
+FROM debian:stretch
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        cabal-install-${CABAL_INSTALL} \
-        ghc-${GHC} && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/*
+        ca-certificates \
+        g++ \
+        gcc \
+        git \
+        gnupg \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.7.3
-ARG STACK_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-ARG STACK_RELEASE_KEY=2C6A674E85EE3FB896AFC9B965101FF31C5C154D
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /opt/ghc/bin /opt/ghc/bin
+COPY --from=builder /opt/ghc/lib /opt/ghc/lib
 
-RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_KEY} && \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_RELEASE_KEY} && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
-    gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    /usr/local/bin/stack config set system-ghc --global true && \
-    /usr/local/bin/stack config set install-ghc --global false && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
+# stack should use global ghc
+RUN /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/${CABAL_INSTALL}/bin:/opt/ghc/${GHC}/bin:$PATH
+# ensure any user gets GHC on the path
+RUN echo 'export PATH="/opt/ghc/bin:$PATH"' >> /etc/profile.d/ghc_path.sh && \
+	chmod +x /etc/profile.d/ghc_path.sh
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/bin:$PATH
 
 CMD ["ghci"]


### PR DESCRIPTION
Closes #45
#40
#43

The current installation method is dependent on [debian ghc and cabal packaging](https://downloads.haskell.org/debian/), which often is slow to be updated. Additionally, ghcup is becoming a standard installation technique of ghc ie. in the github actions, so we probably don't want to reinvent the wheel here.

I believe it also provides an easier path to support windows and arm based images.

## Multi stage file?

I believe it is best that we don't include ghcup in the final image (this point will need to be discussed further). In which case a multi stage file is a nice way to ensure the final image doesn't include any cache used as part of the installation or packages that are only required by ghcup, but not ghc / cabal / stack users.

## Size difference

Old 9.0.1 - 1.5GB
New 9.0.1 - 1.67GB

There may be more that can be stripped out that ghcup is installing, but the debian packages are not. The only other difference I note is the `.so` files are a bit bigger from the ghcup version ie.`base-4.14.1.0/libHSbase-4.14.1.0-ghc8.10.4.so`

ghcup - 12.8MB
debian package - 10.2MB

Still, overall the difference is small enough I'm inclined to ignore it.

## Boot library haddocks

Related to size, I am stripping out `/opt/ghc/share` entirely from the images to save 286MB. The debian ghc package does not entirely remove this, but leaves in the Haddock files for the boot libraries. ie. `/opt/ghc/8.10.4/share/doc/ghc-8.10.4/html/libraries/text-1.2.4.1/text.haddock`. I don't think these are that useful? Or I could leave them in, it would just be a bit more wrangling.

## Other changes

I have also taken this as an opportunity to revise the list of packages we include in the final image. The list is:

- current [stack listed deps](https://github.com/commercialhaskell/stack/blob/master/etc/scripts/get-stack.sh#L199) (new are `gcc`, `libc6-dev`, `libffi-dev`)
- `ca-certificates` which is needed to load stackage urls.
- `libtinfo-dev` which is needed to build `haskeline` (and others?) which is a very common haskell pakage.

### Removed

- `libsqlite3-dev`
- `openssh-client`
- `dirmngr`

I'm not sure if these are old stack or other dependencies or if they are just needed to build the current images. 