### PR TITLE
Support ghc 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7', '9.0.1']
+        ghc: ['8.10.7', '9.0.1', '9.2.1']
         deb: ['buster']
         include:
           - ghc: '8.10.7'
             ghc_minor: '8.10'
           - ghc: '9.0.1'
             ghc_minor: '9.0'
+          - ghc: '9.2.1'
+            ghc_minor: '9.2'
     steps:
       - uses: actions/checkout@v2
       - name: docker build [${{ matrix.ghc }}]

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -1,0 +1,82 @@
+FROM debian:buster
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libsqlite3-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        openssh-client \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG CABAL_INSTALL=3.6.2.0
+ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
+# get from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+ARG CABAL_INSTALL_RELEASE_SHA256=4759B56E9257E02F29FA374A6B25D6CB2F9D80C7E3A55D4F678A8E570925641C
+
+RUN cd /tmp && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${CABAL_INSTALL_RELEASE_KEY} && \
+    curl -fSLO https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS && \
+    curl -fSLO https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS.sig && \
+    gpg --batch --trusted-key B3D9F94B8DCAE210 --verify SHA256SUMS.sig SHA256SUMS && \
+    curl -fSL https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/cabal-install-$CABAL_INSTALL-x86_64-linux-deb10.tar.xz -o cabal-install.tar.gz && \
+    echo "$CABAL_INSTALL_RELEASE_SHA256 cabal-install.tar.gz" | sha256sum --strict --check && \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin && \
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /tmp/*
+
+ARG GHC=9.2.1
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
+# get from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+ARG GHC_RELEASE_SHA256=53F1650ED092230480FF5750B94F409E5DFE66BD07CED00BBBCDF5D6B180234C
+
+RUN cd /tmp && \
+  export GNUPGHOME="$(mktemp -d)" && \
+  curl -sSL https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-x86_64-deb10-linux.tar.xz -o ghc.tar.xz && \
+  curl -sSL https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-x86_64-deb10-linux.tar.xz.sig -o ghc.tar.xz.sig && \
+  gpg --batch --keyserver keyserver.ubuntu.com --receive-keys ${GHC_RELEASE_KEY} && \
+  gpg --batch --trusted-key 2DE04D4E97DB64AD --verify ghc.tar.xz.sig ghc.tar.xz && \
+  echo "$GHC_RELEASE_SHA256 ghc.tar.xz" | sha256sum --strict --check && \
+  tar xf ghc.tar.xz && \
+  cd ghc-$GHC && \
+  ./configure --prefix /opt/ghc/$GHC && \
+  make install && \
+  find /opt/ghc/$GHC/ \( -name "*_p.a" -o -name "*.p_hi" \) -type f -delete && \
+  rm -rf /opt/ghc/$GHC/share/ && \
+  rm -rf "$GNUPGHOME" /tmp/*
+
+ARG STACK=2.7.3
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+# get from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.sha256
+ARG STACK_RELEASE_SHA256=A6C090555FA1C64AA61C29AA4449765A51D79E870CF759CDE192937CD614E72B
+
+RUN cd /tmp && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys ${STACK_RELEASE_KEY} && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz -o stack.tar.gz && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
+    gpg --batch --trusted-key 575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz && \
+    echo "$STACK_RELEASE_SHA256 stack.tar.gz" | sha256sum --strict --check && \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 stack-$STACK-linux-x86_64/stack && \
+    /usr/local/bin/stack config set system-ghc --global true && \
+    /usr/local/bin/stack config set install-ghc --global false && \
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /tmp/*
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]


### PR DESCRIPTION
I have left ghc 8.10 support as 9.0 is not in a good state (9.0.1 has a bunch of issues). For this reason stackage LTS is still on 8.10 as I understand it.

Once 9.0.2 is out I think we should be good to drop 8.10.

ghc 9.2 also needed the `libnuma-dev` package to install.

The `haskell-stack` check fails as stack doesn't know about 9.2.1 yet - `stack --resolver ghc-9.2.1 new myproject` does not work due to unknown compiler. Will wait for this to be resolved before merging. I believe it depends on https://github.com/commercialhaskell/stackage-content/issues/95

EDIT: Not comfortable how long this is blocked, instead I am working on making the stack test gracefully ignore this particular failure https://github.com/docker-library/official-images/pull/11363