### PR TITLE
Improve layer caching between images

### DIFF
--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -25,6 +25,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -115,46 +155,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/8.10/slim-buster/Dockerfile
+++ b/8.10/slim-buster/Dockerfile
@@ -23,6 +23,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -115,46 +155,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -25,6 +25,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -115,46 +155,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.0/slim-buster/Dockerfile
+++ b/9.0/slim-buster/Dockerfile
@@ -23,6 +23,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -115,46 +155,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -25,6 +25,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -98,46 +138,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.2/slim-buster/Dockerfile
+++ b/9.2/slim-buster/Dockerfile
@@ -23,6 +23,46 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
+ARG STACK=2.7.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    INSTALL_STACK="true"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            # Stack does not officially support ARM64, nor do the binaries that exist work.
+            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
+            # stack-2.7.1-linux-aarch64.tar.gz
+            INSTALL_STACK="false"; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    if [ "$INSTALL_STACK" = "true" ]; then \
+        curl -sSL "$STACK_URL" -o stack.tar.gz; \
+        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+        \
+        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+        gpgconf --kill all; \
+        \
+        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+        stack config set system-ghc --global true; \
+        stack config set install-ghc --global false; \
+        \
+        rm -rf /tmp/*; \
+        \
+        stack --version; \
+    fi
+
 ARG CABAL_INSTALL=3.6.2.0
 ARG CABAL_INSTALL_RELEASE_KEY=A970DF3AC3B9709706D74544B3D9F94B8DCAE210
 
@@ -98,46 +138,6 @@ RUN set -eux; \
     rm -rf /tmp/*; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
-
-ARG STACK=2.7.5
-ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
-
-RUN set -eux; \
-    cd /tmp; \
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in \
-        'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
-            ;; \
-        'x86_64') \
-            STACK_SHA256='9bcd165358d4dcafd2b33320d4fe98ce72faaf62300cc9b0fb86a27eb670da50'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
-    esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
 
 ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 


### PR DESCRIPTION
The previous logic to the ordering was order GHC, cabal-install and stack based on how often they get updated. (at the time) Cabal-install was updated the least so it was put as the first install. This minimises the amount of layers invalidated as these tools get updated.

However, upon reflection it is better to the images be more consistent in terms of the initial layers. This way when switching between versions of GHC you only need to download the new GHC layer and not also the stack layer. Also GHC is seeing a lot of releases these days, so that also makes it make sense as the last layer.

Then I put stack as the first install as it is updated less and less.

~Also move the ENV path setting to the top since it almost never changes.~ Nah, it needs to be at the end while the path for GHC is dynamic based on the GHC version. I prefer this path which is more realistic so will leave ENV path setting at the end.