### PR TITLE
fix typo

### DIFF
--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -92,7 +92,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \

--- a/8.10/slim-buster/Dockerfile
+++ b/8.10/slim-buster/Dockerfile
@@ -90,7 +90,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -92,7 +92,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \

--- a/9.0/slim-buster/Dockerfile
+++ b/9.0/slim-buster/Dockerfile
@@ -90,7 +90,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -92,7 +92,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \

--- a/9.2/slim-buster/Dockerfile
+++ b/9.2/slim-buster/Dockerfile
@@ -90,7 +90,7 @@ RUN set -eux; \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
     gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
     gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
-    # confirm we are verying SHA256SUMS that matches the release + sha256
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
     grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
     gpgconf --kill all; \
     \


### PR DESCRIPTION
8.10/buster/Dockerfile
8.10/slim-buster/Dockerfile
9.0/buster/Dockerfile
9.0/slim-buster/Dockerfile
9.2/buster/Dockerfile
9.2/slim-buster/Dockerfile

```sh
$ sed -i 's/verying/verifying/g' docker-haskell/*/*/Dockerfile`
$ 
```