### PR TITLE
Base debian off of buildpack-deps

### DIFF
--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -1,28 +1,11 @@
-FROM debian:buster
+FROM buildpack-deps:buster
 
 ENV LANG C.UTF-8
 
-# common haskell + stack dependencies
+# additional haskell specific deps
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        dpkg-dev \
-        git \
-        gcc \
-        gnupg \
-        g++ \
-        libc6-dev \
-        libffi-dev \
-        libgmp-dev \
-        libnuma-dev \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG STACK=2.7.5

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -1,28 +1,12 @@
-FROM debian:buster
+FROM buildpack-deps:buster
 
 ENV LANG C.UTF-8
 
-# common haskell + stack dependencies
+# additional haskell specific deps
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        dpkg-dev \
-        git \
-        gcc \
-        gnupg \
-        g++ \
-        libc6-dev \
-        libffi-dev \
-        libgmp-dev \
         libnuma-dev \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG STACK=2.7.5

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -1,28 +1,11 @@
-FROM debian:buster
+FROM buildpack-deps:buster
 
 ENV LANG C.UTF-8
 
-# common haskell + stack dependencies
+# additional haskell specific deps
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        dpkg-dev \
-        git \
-        gcc \
-        gnupg \
-        g++ \
-        libc6-dev \
-        libffi-dev \
-        libgmp-dev \
-        libnuma-dev \
-        libsqlite3-dev \
-        libtinfo-dev \
-        make \
-        netbase \
-        openssh-client \
-        xz-utils \
-        zlib1g-dev && \
+        libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG STACK=2.7.5


### PR DESCRIPTION
This is quite standard for official images and makes them more batteries included.

The downside is the images increase from 2.5GB to 2.8GB ish, but I think that is worth it as the buildpack-deps base image will often be cached already due to how common it is. When the base image is cached the end user is pulling less GBs.

This also removes the `libnuma-dev` dependency for 9+ which as I understand it was a [mistake](https://gitlab.haskell.org/ghc/ghc/-/issues/20957) which is fixed in ~9.0.2~ (nope not fixed in 9.0 branch) + 9.2.2.