### PR TITLE
Update README to reflect new IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@
 
 If you have any problems with or questions about this image, please contact us through a [GitHub issue](%%GITHUB-REPO%%/issues).
 
-You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Freenode](https://freenode.net).
+You can also reach many of the official image maintainers via the `#docker-library` IRC channel on [Libera](https://libera.chat/).
 
 You are invited to contribute new features, fixes, or updates directly via pull requests on GitHub.


### PR DESCRIPTION
It looks like you migrated to Libera.Chat, based on the current channel population.