### PR TITLE
Install libnuma always

### DIFF
--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -5,6 +5,7 @@ ENV LANG C.UTF-8
 # additional haskell specific deps
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        libnuma-dev \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -5,6 +5,7 @@ ENV LANG C.UTF-8
 # additional haskell specific deps
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        libnuma-dev \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
closes #81

It was a bit unclear if this is always required, but seems it is
good to install it to be safe as there are edge cases where it is
needed.

Also this was installed in all the slim images and it should be
consistent.