### PR TITLE
Bump stack to 2.9.3

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.3']
+        ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.4']
         deb: ['buster', 'slim-buster']
         include:
           - ghc: '8.10.7'
@@ -31,7 +31,7 @@ jobs:
             ghc_minor: '9.0'
           - ghc: '9.2.5'
             ghc_minor: '9.2'
-          - ghc: '9.4.3'
+          - ghc: '9.4.4'
             ghc_minor: '9.4'
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.3']
+        ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.4']
         # uraimo/run-on-arch-action does not support debian slim variants
         deb: ['buster']
         arch: ['aarch64']
@@ -70,7 +70,7 @@ jobs:
             ghc_minor: '9.0'
           - ghc: '9.2.5'
             ghc_minor: '9.2'
-          - ghc: '9.4.3'
+          - ghc: '9.4.4'
             ghc_minor: '9.4'
           - arch: aarch64
             docker_platform: arm64

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -9,45 +9,39 @@ RUN apt-get update && \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/8.10/slim-buster/Dockerfile
+++ b/8.10/slim-buster/Dockerfile
@@ -23,45 +23,39 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -9,45 +9,39 @@ RUN apt-get update && \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.0/slim-buster/Dockerfile
+++ b/9.0/slim-buster/Dockerfile
@@ -23,45 +23,39 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -9,45 +9,39 @@ RUN apt-get update && \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.2/slim-buster/Dockerfile
+++ b/9.2/slim-buster/Dockerfile
@@ -23,45 +23,39 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.4/buster/Dockerfile
+++ b/9.4/buster/Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
     \
     cabal --version
 
-ARG GHC=9.4.3
+ARG GHC=9.4.4
 ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
 
 RUN set -eux; \
@@ -90,10 +90,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            GHC_SHA256='9694131b02f938e72e1740b772ff1c1c81a36ef44233dc230bbd978e7dd08e71'; \
+            GHC_SHA256='2c0f22a7430490be3071f88240761bd7aadb7d40f22c6b9f1d2485ffcdf4e2e0'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='940ac2b1770dc63b5f3f38f829bfe69f4a572d6b26cd93094cdd99d5300b5067'; \
+            GHC_SHA256='a3ecd2426bb519d6fdad05904c386f1c74b433f07722b0d1ef606c23159ade2d'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.4/buster/Dockerfile
+++ b/9.4/buster/Dockerfile
@@ -9,45 +9,39 @@ RUN apt-get update && \
         libtinfo-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C

--- a/9.4/slim-buster/Dockerfile
+++ b/9.4/slim-buster/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
     \
     cabal --version
 
-ARG GHC=9.4.3
+ARG GHC=9.4.4
 ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
 
 RUN set -eux; \
@@ -104,10 +104,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            GHC_SHA256='9694131b02f938e72e1740b772ff1c1c81a36ef44233dc230bbd978e7dd08e71'; \
+            GHC_SHA256='2c0f22a7430490be3071f88240761bd7aadb7d40f22c6b9f1d2485ffcdf4e2e0'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='940ac2b1770dc63b5f3f38f829bfe69f4a572d6b26cd93094cdd99d5300b5067'; \
+            GHC_SHA256='a3ecd2426bb519d6fdad05904c386f1c74b433f07722b0d1ef606c23159ade2d'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.4/slim-buster/Dockerfile
+++ b/9.4/slim-buster/Dockerfile
@@ -23,45 +23,39 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG STACK=2.9.1
+ARG STACK=2.9.3
 ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
 
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    INSTALL_STACK="true"; \
     STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
     # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
     case "$ARCH" in \
         'aarch64') \
-            # Stack does not officially support ARM64, nor do the binaries that exist work.
-            # Hitting https://github.com/commercialhaskell/stack/issues/2103#issuecomment-972329065 when trying to use
-            # stack-2.7.1-linux-aarch64.tar.gz
-            INSTALL_STACK="false"; \
+            STACK_SHA256='161e1638da9efc56319f7225b3652ca3f339bcda9eadc7d6ce512f325b0f014a'; \
             ;; \
         'x86_64') \
-            STACK_SHA256='0581cebe880b8ed47556ee73d8bbb9d602b5b82e38f89f6aa53acaec37e7760d'; \
+            STACK_SHA256='938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
-    if [ "$INSTALL_STACK" = "true" ]; then \
-        curl -sSL "$STACK_URL" -o stack.tar.gz; \
-        echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
-        \
-        curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
-        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-        gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
-        gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
-        gpgconf --kill all; \
-        \
-        tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
-        stack config set system-ghc --global true; \
-        stack config set install-ghc --global false; \
-        \
-        rm -rf /tmp/*; \
-        \
-        stack --version; \
-    fi
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
 
 ARG CABAL_INSTALL=3.8.1.0
 ARG CABAL_INSTALL_RELEASE_KEY=E9EC5616017C3EE26B33468CCE1ED8AE0B011D8C


### PR DESCRIPTION
This version should support aarch64.

This is just testing the release candidate for now.