### PR TITLE
Add bullseye variant of 9.6.6 images

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -87,10 +87,12 @@ jobs:
             ghc_minor: '9.10'
             deb: 'bullseye'
             arch: 'aarch64'
+            docker_platform: arm64
           - ghc: '9.6.6'
             ghc_minor: '9.6'
             deb: 'bullseye'
             arch: 'aarch64'
+            docker_platform: arm64
           # buster (debian 10)
           - ghc: '9.10.1'
             ghc_minor: '9.10'
@@ -119,7 +121,7 @@ jobs:
             apt-get install -y curl
             curl -fsSL https://get.docker.com | sh
           run: |
-            docker build --pull \
+            docker build --pull --progress=plain \
               --platform "linux/${{ matrix.docker_platform }}" \
               -t haskell:${{ matrix.ghc }}-${{ matrix.deb }} \
               ${{ matrix.ghc_minor }}/${{ matrix.deb }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -82,6 +82,16 @@ jobs:
         deb: ['buster']
         arch: ['aarch64']
         include:
+          # bullseye (debian 11)
+          - ghc: '9.10.1'
+            ghc_minor: '9.10'
+            deb: 'bullseye'
+            arch: 'aarch64'
+          - ghc: '9.6.6'
+            ghc_minor: '9.6'
+            deb: 'bullseye'
+            arch: 'aarch64'
+          # buster (debian 10)
           - ghc: '9.10.1'
             ghc_minor: '9.10'
           - ghc: '9.8.2'

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - master
     paths:
+      - '**/bullseye/Dockerfile'
       - '**/buster/Dockerfile'
+      - '**/slim-bullseye/Dockerfile'
       - '**/slim-buster/Dockerfile'
       - '.github/workflows/debian.yml'
 
@@ -35,6 +37,12 @@ jobs:
             ghc_minor: '9.10'
           - ghc: '9.8.2'
             ghc_minor: '9.8'
+          - ghc: '9.6.6'
+            ghc_minor: '9.6'
+            deb: 'slim-bullseye'
+          - ghc: '9.6.6'
+            ghc_minor: '9.6'
+            deb: 'bullseye'
           - ghc: '9.6.6'
             ghc_minor: '9.6'
           - ghc: '9.4.8'

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -1,0 +1,121 @@
+FROM buildpack-deps:bullseye
+
+ENV LANG C.UTF-8
+
+# additional haskell specific deps
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libnuma-dev \
+        libtinfo-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=2.15.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='52cd9d9c2ee4dbf2841bba856f5fca15fbf6ba23fced7256aa3f7c8b76381c91'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='d55f8554932aad23f7b1198e0d5ebe332073d73fe60e3f324d0b315c156d8c43'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.10.3.0
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='c14e8198407f37f7276c77b5cefef60ee6a929b4c22d7316577ce8e2301a758e'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='4f60cf1c72f4ad4d82d668839ac61ae15ae4faf6c4b809395799e8a3ee622051'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.6.6
+ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        # TODO 'aarch64' not available in https://downloads.haskell.org/~ghc/9.6.6/
+        # 'aarch64') \
+        #     GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
+        #     ;; \
+        'x86_64') \
+            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -86,16 +86,17 @@ ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
-    # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
+            # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
+            # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
             GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='15ee68cede5d114a672fb468b9545700edd70a68724ab4e9122c8a23aba8570b'; \
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -1,12 +1,26 @@
-FROM buildpack-deps:bullseye
+FROM debian:bullseye
 
 ENV LANG C.UTF-8
 
-# additional haskell specific deps
+# common haskell + stack dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
         libnuma-dev \
-        libtinfo-dev && \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG STACK=2.15.5

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -86,15 +86,16 @@ ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
+    # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
-        # TODO 'aarch64' not available in https://downloads.haskell.org/~ghc/9.6.6/
-        # 'aarch64') \
-        #     GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
-        #     ;; \
+        'aarch64') \
+            GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
+            ;; \
         'x86_64') \
-            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
+            GHC_SHA256='15ee68cede5d114a672fb468b9545700edd70a68724ab4e9122c8a23aba8570b'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -55,10 +55,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            CABAL_INSTALL_SHA256='c14e8198407f37f7276c77b5cefef60ee6a929b4c22d7316577ce8e2301a758e'; \
+            CABAL_INSTALL_SHA256='e0b6604d3596c5e5b7236e79ff4f5aa8af337792bf69ac4a90634c761f1b9ed5'; \
             ;; \
         'x86_64') \
-            CABAL_INSTALL_SHA256='4f60cf1c72f4ad4d82d668839ac61ae15ae4faf6c4b809395799e8a3ee622051'; \
+            CABAL_INSTALL_SHA256='12d018bdd07efed470f278f22d94b33655c4fcbc44d28d97b5ebb7944d5607c5'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
     esac; \

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -100,15 +100,16 @@ ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
+    # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
-        # TODO 'aarch64' not available in https://downloads.haskell.org/~ghc/9.6.6/
-        # 'aarch64') \
-        #     GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
-        #     ;; \
+        'aarch64') \
+            GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
+            ;; \
         'x86_64') \
-            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
+            GHC_SHA256='15ee68cede5d114a672fb468b9545700edd70a68724ab4e9122c8a23aba8570b'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -69,10 +69,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            CABAL_INSTALL_SHA256='c14e8198407f37f7276c77b5cefef60ee6a929b4c22d7316577ce8e2301a758e'; \
+            CABAL_INSTALL_SHA256='e0b6604d3596c5e5b7236e79ff4f5aa8af337792bf69ac4a90634c761f1b9ed5'; \
             ;; \
         'x86_64') \
-            CABAL_INSTALL_SHA256='4f60cf1c72f4ad4d82d668839ac61ae15ae4faf6c4b809395799e8a3ee622051'; \
+            CABAL_INSTALL_SHA256='12d018bdd07efed470f278f22d94b33655c4fcbc44d28d97b5ebb7944d5607c5'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
     esac; \

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -100,16 +100,17 @@ ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
-    # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
+            # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
+            # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
             GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='15ee68cede5d114a672fb468b9545700edd70a68724ab4e9122c8a23aba8570b'; \
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -1,0 +1,137 @@
+FROM debian:bullseye-slim
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=2.15.5
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='52cd9d9c2ee4dbf2841bba856f5fca15fbf6ba23fced7256aa3f7c8b76381c91'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='d55f8554932aad23f7b1198e0d5ebe332073d73fe60e3f324d0b315c156d8c43'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.10.3.0
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='c14e8198407f37f7276c77b5cefef60ee6a929b4c22d7316577ce8e2301a758e'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='4f60cf1c72f4ad4d82d668839ac61ae15ae4faf6c4b809395799e8a3ee622051'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.6.6
+ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        # TODO 'aarch64' not available in https://downloads.haskell.org/~ghc/9.6.6/
+        # 'aarch64') \
+        #     GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
+        #     ;; \
+        'x86_64') \
+            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    # remove profiling support to save space
+    find "/opt/ghc/$GHC/" \( -name "*_p.a" -o -name "*.p_hi" \) -type f -delete; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]


### PR DESCRIPTION
I'm trying to emulate what was done for 9.10 in https://github.com/haskell/docker-haskell/pull/134

I basically copy-pasted buster dockerfiles, and just changed deb10 -> deb11 (+ updated checksums).
After noticing that deb11 variant of 9.6.6 ghc binaries don't exist, I asked on ghc matrix and Julian Osphald (ghcup dev) told me it shouldn't matter, because deb10 binaries should be binary compatible with deb11, so I should use those insead.

Here's the output of `git diff --no-index 9.6/slim-buster/Dockerfile 9.6/slim-bullseye/Dockerfile` which makes it clearer how the new bullseye images differ from buster ones.


```diff
diff --git a/9.6/slim-buster/Dockerfile b/9.6/slim-bullseye/Dockerfile
index 66d2100..837726b 100644
--- a/9.6/slim-buster/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV LANG C.UTF-8
 
@@ -63,16 +63,16 @@ ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb10.tar.xz"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
     CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
     CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
     # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            CABAL_INSTALL_SHA256='92d341620c60294535f03098bff796ef6de2701de0c4fcba249cde18a2923013'; \
+            CABAL_INSTALL_SHA256='e0b6604d3596c5e5b7236e79ff4f5aa8af337792bf69ac4a90634c761f1b9ed5'; \
             ;; \
         'x86_64') \
-            CABAL_INSTALL_SHA256='1d7a7131402295b01f25be5373fde095a404c45f9b5a5508fb7474bb0d3d057a'; \
+            CABAL_INSTALL_SHA256='12d018bdd07efed470f278f22d94b33655c4fcbc44d28d97b5ebb7944d5607c5'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
     esac; \
@@ -100,14 +100,17 @@ ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
 RUN set -eux; \
     cd /tmp; \
     ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
+            # Note: the 'aarch64-deb11' (bullseye) variant of images doesn't exist in https://downloads.haskell.org/~ghc/9.6.6/
+            # But deb10 (buster) images should be binary compatible with deb11, so using deb10 instead
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb10-linux.tar.xz"; \
             GHC_SHA256='58d5ce65758ec5179b448e4e1a2f835924b4ada96cf56af80d011bed87d91fef'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='15ee68cede5d114a672fb468b9545700edd70a68724ab4e9122c8a23aba8570b'; \
+            GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+            GHC_SHA256='a34bdfc1f65b000135d9c8eb12d69670026a64043a8b33ef5ba24b0f8e28d046'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \
```