### PR TITLE
feat: Bump GHC 9.8.4 + add bullseye image for 9.8.4

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -37,6 +37,12 @@ jobs:
             ghc_minor: '9.10'
           - ghc: '9.8.4'
             ghc_minor: '9.8'
+            deb: 'slim-bullseye'
+          - ghc: '9.8.4'
+            ghc_minor: '9.8'
+            deb: 'bullseye'
+          - ghc: '9.8.4'
+            ghc_minor: '9.8'
           - ghc: '9.6.6'
             ghc_minor: '9.6'
             deb: 'slim-bullseye'
@@ -85,6 +91,11 @@ jobs:
           # bullseye (debian 11)
           - ghc: '9.10.1'
             ghc_minor: '9.10'
+            deb: 'bullseye'
+            arch: 'aarch64'
+            docker_platform: arm64
+          - ghc: '9.8.4'
+            ghc_minor: '9.8'
             deb: 'bullseye'
             arch: 'aarch64'
             docker_platform: arm64

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.10.1', '9.8.2', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
+        ghc: ['9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
         deb: ['buster', 'slim-buster']
         include:
           - ghc: '9.10.1'
@@ -35,7 +35,7 @@ jobs:
             deb: 'bullseye'
           - ghc: '9.10.1'
             ghc_minor: '9.10'
-          - ghc: '9.8.2'
+          - ghc: '9.8.4'
             ghc_minor: '9.8'
           - ghc: '9.6.6'
             ghc_minor: '9.6'
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.2', '9.10.1']
+        ghc: ['9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1']
         # uraimo/run-on-arch-action does not support debian slim variants
         deb: ['buster']
         arch: ['aarch64']
@@ -96,7 +96,7 @@ jobs:
           # buster (debian 10)
           - ghc: '9.10.1'
             ghc_minor: '9.10'
-          - ghc: '9.8.2'
+          - ghc: '9.8.4'
             ghc_minor: '9.8'
           - ghc: '9.6.6'
             ghc_minor: '9.6'

--- a/9.8/bullseye/Dockerfile
+++ b/9.8/bullseye/Dockerfile
@@ -1,0 +1,134 @@
+FROM debian:bullseye
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=3.1.1
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='033cb75bad3a5299b522c99e8056915bd081879f5df312e6d44d7511fc567455'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='d096125ea3d987a55d17f7d4f8599ee2fd96bd2d0f033566e28ddfe248f730f9'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.10.3.0
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='e0b6604d3596c5e5b7236e79ff4f5aa8af337792bf69ac4a90634c761f1b9ed5'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='12d018bdd07efed470f278f22d94b33655c4fcbc44d28d97b5ebb7944d5607c5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.8.4
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]

--- a/9.8/buster/Dockerfile
+++ b/9.8/buster/Dockerfile
@@ -80,8 +80,8 @@ RUN set -eux; \
     \
     cabal --version
 
-ARG GHC=9.8.2
-ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
+ARG GHC=9.8.4
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
 
 RUN set -eux; \
     cd /tmp; \
@@ -90,10 +90,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            GHC_SHA256='9a3776fd8dc02f95b751f0e44823d6727dea2c212857e2c5c5f6a38a034d1575'; \
+            GHC_SHA256='15cf9341437af2c6f75bbaf8222824f5b51c32f0637ed054513f165999b0a87d'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='7449e1c8ef351ec326f36d9eba2885ba7b75d9900df35b2069c4d6fd151b09eb'; \
+            GHC_SHA256='26bc72eb2758a3df14a4a88193d116d2cf334c2a20892b401f5cd3f82e6d346c'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \

--- a/9.8/slim-bullseye/Dockerfile
+++ b/9.8/slim-bullseye/Dockerfile
@@ -1,0 +1,134 @@
+FROM debian:bullseye-slim
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=3.1.1
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='033cb75bad3a5299b522c99e8056915bd081879f5df312e6d44d7511fc567455'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='d096125ea3d987a55d17f7d4f8599ee2fd96bd2d0f033566e28ddfe248f730f9'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.10.3.0
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='e0b6604d3596c5e5b7236e79ff4f5aa8af337792bf69ac4a90634c761f1b9ed5'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='12d018bdd07efed470f278f22d94b33655c4fcbc44d28d97b5ebb7944d5607c5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.8.4
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]

--- a/9.8/slim-buster/Dockerfile
+++ b/9.8/slim-buster/Dockerfile
@@ -94,8 +94,8 @@ RUN set -eux; \
     \
     cabal --version
 
-ARG GHC=9.8.2
-ARG GHC_RELEASE_KEY=88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4
+ARG GHC=9.8.4
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
 
 RUN set -eux; \
     cd /tmp; \
@@ -104,10 +104,10 @@ RUN set -eux; \
     # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
     case "$ARCH" in \
         'aarch64') \
-            GHC_SHA256='9a3776fd8dc02f95b751f0e44823d6727dea2c212857e2c5c5f6a38a034d1575'; \
+            GHC_SHA256='15cf9341437af2c6f75bbaf8222824f5b51c32f0637ed054513f165999b0a87d'; \
             ;; \
         'x86_64') \
-            GHC_SHA256='7449e1c8ef351ec326f36d9eba2885ba7b75d9900df35b2069c4d6fd151b09eb'; \
+            GHC_SHA256='26bc72eb2758a3df14a4a88193d116d2cf334c2a20892b401f5cd3f82e6d346c'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
     esac; \


### PR DESCRIPTION
Bumping 9.8.2 to 9.8.4.
Adding a bullseye variant of version 9.8.4 based on #134

[Stackage LTS 23](https://www.stackage.org/blog/2024/12/announce-lts-23-nightly-ghc-9.10) released recently, which needs ghc 9.8.4

### Info
Download: https://downloads.haskell.org/ghc/9.8.4/
Blog: https://www.haskell.org/ghc/blog/20241202-ghc-9.8.4-released.html