### PR TITLE
Bump uraimo/run-on-arch-action to v2.8.1

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: docker build [ ${{ matrix.arch }} ${{ matrix.ghc }}]
-        uses: uraimo/run-on-arch-action@v2.7.2
+        uses: uraimo/run-on-arch-action@v2.8.1
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.deb }}


### PR DESCRIPTION
I'm trying to figure out why aarch64-9.10.1-bullseye and aarch64-9.6.6-bullseye suddenly started failing with errors like
```
  #2 [internal] load metadata for docker.io/arm64v8/debian:bullseye
  #2 ERROR: no match for platform in manifest: not found
  ------
   > [internal] load metadata for docker.io/arm64v8/debian:bullseye:
  ------
  Dockerfile.aarch64.bullseye:1
  --------------------
     1 | >>> FROM arm64v8/debian:bullseye
     2 |     
     3 |     COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
  --------------------
  ERROR: failed to solve: arm64v8/debian:bullseye: failed to resolve source metadata for docker.io/arm64v8/debian:bullseye: no match for platform in manifest: not found
  Error: The process '/home/runner/work/_actions/uraimo/run-on-arch-action/v2.7.2/src/run-on-arch.sh' failed with exit code 1
```

I *think* it could have something to do with what's being fixed in https://github.com/uraimo/run-on-arch-action/releases/tag/v2.8.0 .. let's try.

