### PR TITLE
Feat: Update CI

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-smoke-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: ${{ matrix.ghc }}-${{ matrix.deb }}
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
 
   emulated-architecture-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: ${{ matrix.arch }}-${{ matrix.ghc }}-${{ matrix.deb }}
     strategy:
       fail-fast: false

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -68,7 +68,8 @@ jobs:
           command: |
             docker build --pull \
               -t haskell:${{ matrix.ghc }}-${{ matrix.deb }} \
-              ${{ matrix.ghc_minor }}/${{ matrix.deb }}
+              ${{ matrix.ghc_minor }}/${{ matrix.deb }} \
+              --build-arg "BUILDKIT_DOCKERFILE_CHECK=skip=SecretsUsedInArgOrEnv;error=true"
       - uses: actions/checkout@v4
         with:
           repository: docker-library/official-images
@@ -135,7 +136,8 @@ jobs:
             docker build --pull --progress=plain \
               --platform "linux/${{ matrix.docker_platform }}" \
               -t haskell:${{ matrix.ghc }}-${{ matrix.deb }} \
-              ${{ matrix.ghc_minor }}/${{ matrix.deb }}
+              ${{ matrix.ghc_minor }}/${{ matrix.deb }} \
+              --build-arg "BUILDKIT_DOCKERFILE_CHECK=skip=SecretsUsedInArgOrEnv;error=true"
             echo 'testing..'
             docker run \
               --platform "linux/${{ matrix.docker_platform }}" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   hadolint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: hadolint/hadolint-action@v3.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: hadolint/hadolint-action@v1.6.0
+    - uses: hadolint/hadolint-action@v3.1.0
       with:
         recursive: true

--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # additional haskell specific deps
 RUN apt-get update && \
@@ -132,6 +132,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.0/slim-buster/Dockerfile
+++ b/9.0/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -148,6 +148,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.10/bullseye/Dockerfile
+++ b/9.10/bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.10/buster/Dockerfile
+++ b/9.10/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.10/slim-bullseye/Dockerfile
+++ b/9.10/slim-bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.10/slim-buster/Dockerfile
+++ b/9.10/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -131,6 +131,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # additional haskell specific deps
 RUN apt-get update && \
@@ -115,6 +115,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.2/slim-buster/Dockerfile
+++ b/9.2/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -131,6 +131,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.4/buster/Dockerfile
+++ b/9.4/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # additional haskell specific deps
 RUN apt-get update && \
@@ -115,6 +115,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.4/slim-buster/Dockerfile
+++ b/9.4/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -131,6 +131,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -132,6 +132,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.6/buster/Dockerfile
+++ b/9.6/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # additional haskell specific deps
 RUN apt-get update && \
@@ -115,6 +115,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -134,6 +134,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.6/slim-buster/Dockerfile
+++ b/9.6/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -131,6 +131,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.8/bullseye/Dockerfile
+++ b/9.8/bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.8/buster/Dockerfile
+++ b/9.8/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:buster
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # additional haskell specific deps
 RUN apt-get update && \
@@ -115,6 +115,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.8/slim-bullseye/Dockerfile
+++ b/9.8/slim-bullseye/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.8/slim-buster/Dockerfile
+++ b/9.8/slim-buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -131,6 +131,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]


### PR DESCRIPTION
This fixes two Errors I encountered while working on #145 and #143 

- [x] We use the `ubuntu-latest` github action runners, which used to be `ubuntu-24.04` but is going to be switched to `ubuntu-24.04` soon (see https://github.com/actions/runner-images/issues/10636)
This produces a ton of warnings: 
```
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
```

in the CI runs, and it's generally a better idea to be explicit about that. 

Since we don't use a ton of special features or packages, that may break from that transition, it is a good idea to use the newer one (`ubuntu-24.04`). If you paid close attention to recent CI runs, some / nearly all already used `ubuntu-24.04`.

- [x] I saw some docker build warnings while I worked on #145 and maybe they can be reported by hadolint already. So I looked at the used version in the CI and it was outdated, so hopefully some new errors / warnings will be found by the newer action (I doubt it, as my local hadolint installation didn't warn me about these warnings, but lets' see 🤷🏼‍♂️ )

This is actually possible, by making [checks](https://docs.docker.com/build/checks/) a fatal error instead of a warning. See [here](https://docs.docker.com/build/checks/#fail-build-on-check-violations)

I also skipped one check: `SecretsUsedInArgOrEnv`, since this check detects all GPG KEY `ARG`directives as an error, which they aren't. 
I fixed all remaining errors, which only were `LegacyKeyValueFormat`
