### PR TITLE
feat: ghc 9.12.2, cabal 3.14.1.1 and stack 3.1.1 on bookworm

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - master
     paths:
+      - '**/bookworm/Dockerfile'
       - '**/bullseye/Dockerfile'
       - '**/buster/Dockerfile'
+      - '**/slim-bookworm/Dockerfile'
       - '**/slim-bullseye/Dockerfile'
       - '**/slim-buster/Dockerfile'
       - '.github/workflows/debian.yml'

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -24,9 +24,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
-        deb: ['buster', 'slim-buster']
+        ghc: ['9.12.1', '9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
+        deb: ['bookworm', 'slim-bookworm', 'bullseye', 'slim-bullseye']
         include:
+          - ghc: '9.12.2'
+            ghc_minor: '9.12'
+            deb: 'slim-bookworm'
+          - ghc: '9.12.2'
+            ghc_minor: '9.12'
+            deb: 'bookworm'
           - ghc: '9.10.1'
             ghc_minor: '9.10'
             deb: 'slim-bullseye'
@@ -84,11 +90,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1']
+        ghc: ['9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1', '9.12.2']
         # uraimo/run-on-arch-action does not support debian slim variants
-        deb: ['buster']
+        deb: ['bullseye', 'bookworm']
         arch: ['aarch64']
         include:
+          # bookworm (debian 12)
+          - ghc: '9.12.2'
+            ghc_minor: '9.12'
+            deb: 'bookworm'
+            arch: 'aarch64'
+            docker_platform: arm64
           # bullseye (debian 11)
           - ghc: '9.10.1'
             ghc_minor: '9.10'
@@ -123,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: docker build [ ${{ matrix.arch }} ${{ matrix.ghc }}]
-        uses: uraimo/run-on-arch-action@v2.8.1
+        uses: uraimo/run-on-arch-action@v3.0.0
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.deb }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -26,75 +26,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ghc: ['9.12.2', '9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2']
+        deb: ['buster', 'slim-buster']
         include:
-          # 9.12.2
           - ghc: '9.12.2'
             ghc_minor: '9.12'
             deb: 'bookworm'
           - ghc: '9.12.2'
             ghc_minor: '9.12'
             deb: 'slim-bookworm'
-          # 9.10.1
+          - ghc: '9.10.1'
+            ghc_minor: '9.10'
+            deb: 'slim-bullseye'
           - ghc: '9.10.1'
             ghc_minor: '9.10'
             deb: 'bullseye'
           - ghc: '9.10.1'
             ghc_minor: '9.10'
+          - ghc: '9.8.4'
+            ghc_minor: '9.8'
             deb: 'slim-bullseye'
-          # - ghc: '9.10.1'
-          #   ghc_minor: '9.10'
-          #   deb: 'buster'
-          # - ghc: '9.10.1'
-          #   ghc_minor: '9.10'
-          #   deb: 'slim-buster'
-          # 9.8.4
           - ghc: '9.8.4'
             ghc_minor: '9.8'
             deb: 'bullseye'
           - ghc: '9.8.4'
             ghc_minor: '9.8'
+          - ghc: '9.6.6'
+            ghc_minor: '9.6'
             deb: 'slim-bullseye'
-          # - ghc: '9.8.4'
-          #   ghc_minor: '9.8'
-          #   deb: 'buster'
-          # - ghc: '9.8.4'
-          #   ghc_minor: '9.8'
-          #   deb: 'slim-buster'
-          # 9.6.6
           - ghc: '9.6.6'
             ghc_minor: '9.6'
             deb: 'bullseye'
           - ghc: '9.6.6'
             ghc_minor: '9.6'
-            deb: 'slim-bullseye'
-          # - ghc: '9.6.6'
-          #   ghc_minor: '9.6'
-          #   deb: 'buster'
-          # - ghc: '9.6.6'
-          #   ghc_minor: '9.6'
-          #   deb: 'slim-buster'
-          # 9.4.8
-          # - ghc: '9.4.8'
-          #   ghc_minor: '9.4'
-          #   deb: 'buster'
-          # - ghc: '9.4.8'
-          #   ghc_minor: '9.4'
-          #   deb: 'slim-buster'
-          # 9.2.8
-          # - ghc: '9.2.8'
-          #   ghc_minor: '9.2'
-          #   deb: 'buster'
-          # - ghc: '9.2.8'
-          #   ghc_minor: '9.2'
-          #   deb: 'slim-buster'
-          # 9.0.2
-          # - ghc: '9.0.2'
-          #   ghc_minor: '9.0'
-          #   deb: 'buster'
-          # - ghc: '9.0.2'
-          #   ghc_minor: '9.0'
-          #   deb: 'slim-buster'
-
+          - ghc: '9.4.8'
+            ghc_minor: '9.4'
+          - ghc: '9.2.8'
+            ghc_minor: '9.2'
+          - ghc: '9.0.2'
+            ghc_minor: '9.0'
+        exclude:
+          - ghc: '9.12.2'
+            deb: 'buster'
+          - ghc: '9.12.2'
+            deb: 'slim-buster'
     steps:
       - uses: actions/checkout@v4
       - name: build + smoke test [${{ matrix.ghc }}]
@@ -125,9 +100,6 @@ jobs:
         # uraimo/run-on-arch-action does not support debian slim variants
         deb: ['buster']
         arch: ['aarch64']
-        exclude:
-          - ghc: '9.12.2'
-            deb: 'buster'
         include:
           # bookworm (debian 12)
           - ghc: '9.12.2'
@@ -166,6 +138,10 @@ jobs:
             ghc_minor: '9.0'
           - arch: aarch64
             docker_platform: arm64
+        exclude:
+          - ghc: '9.12.2'
+            deb: 'buster'
+
     steps:
       - uses: actions/checkout@v4
       - name: docker build [ ${{ matrix.arch }} ${{ matrix.ghc }}]

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.12.1', '9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
-        deb: ['bookworm', 'slim-bookworm', 'bullseye', 'slim-bullseye']
+        ghc: ['9.12.2', '9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
+        deb: ['buster', 'slim-buster']
         include:
           - ghc: '9.12.2'
             ghc_minor: '9.12'
@@ -92,7 +92,7 @@ jobs:
       matrix:
         ghc: ['9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1', '9.12.2']
         # uraimo/run-on-arch-action does not support debian slim variants
-        deb: ['bullseye', 'bookworm']
+        deb: ['buster']
         arch: ['aarch64']
         include:
           # bookworm (debian 12)

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -26,45 +26,74 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.12.2', '9.10.1', '9.8.4', '9.6.6', '9.4.8', '9.2.8', '9.0.2' ]
-        deb: ['buster', 'slim-buster']
         include:
-          - ghc: '9.12.2'
-            ghc_minor: '9.12'
-            deb: 'slim-bookworm'
+          # 9.12.2
           - ghc: '9.12.2'
             ghc_minor: '9.12'
             deb: 'bookworm'
-          - ghc: '9.10.1'
-            ghc_minor: '9.10'
-            deb: 'slim-bullseye'
+          - ghc: '9.12.2'
+            ghc_minor: '9.12'
+            deb: 'slim-bookworm'
+          # 9.10.1
           - ghc: '9.10.1'
             ghc_minor: '9.10'
             deb: 'bullseye'
           - ghc: '9.10.1'
             ghc_minor: '9.10'
-          - ghc: '9.8.4'
-            ghc_minor: '9.8'
             deb: 'slim-bullseye'
+          # - ghc: '9.10.1'
+          #   ghc_minor: '9.10'
+          #   deb: 'buster'
+          # - ghc: '9.10.1'
+          #   ghc_minor: '9.10'
+          #   deb: 'slim-buster'
+          # 9.8.4
           - ghc: '9.8.4'
             ghc_minor: '9.8'
             deb: 'bullseye'
           - ghc: '9.8.4'
             ghc_minor: '9.8'
-          - ghc: '9.6.6'
-            ghc_minor: '9.6'
             deb: 'slim-bullseye'
+          # - ghc: '9.8.4'
+          #   ghc_minor: '9.8'
+          #   deb: 'buster'
+          # - ghc: '9.8.4'
+          #   ghc_minor: '9.8'
+          #   deb: 'slim-buster'
+          # 9.6.6
           - ghc: '9.6.6'
             ghc_minor: '9.6'
             deb: 'bullseye'
           - ghc: '9.6.6'
             ghc_minor: '9.6'
-          - ghc: '9.4.8'
-            ghc_minor: '9.4'
-          - ghc: '9.2.8'
-            ghc_minor: '9.2'
-          - ghc: '9.0.2'
-            ghc_minor: '9.0'
+            deb: 'slim-bullseye'
+          # - ghc: '9.6.6'
+          #   ghc_minor: '9.6'
+          #   deb: 'buster'
+          # - ghc: '9.6.6'
+          #   ghc_minor: '9.6'
+          #   deb: 'slim-buster'
+          # 9.4.8
+          # - ghc: '9.4.8'
+          #   ghc_minor: '9.4'
+          #   deb: 'buster'
+          # - ghc: '9.4.8'
+          #   ghc_minor: '9.4'
+          #   deb: 'slim-buster'
+          # 9.2.8
+          # - ghc: '9.2.8'
+          #   ghc_minor: '9.2'
+          #   deb: 'buster'
+          # - ghc: '9.2.8'
+          #   ghc_minor: '9.2'
+          #   deb: 'slim-buster'
+          # 9.0.2
+          # - ghc: '9.0.2'
+          #   ghc_minor: '9.0'
+          #   deb: 'buster'
+          # - ghc: '9.0.2'
+          #   ghc_minor: '9.0'
+          #   deb: 'slim-buster'
 
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +125,9 @@ jobs:
         # uraimo/run-on-arch-action does not support debian slim variants
         deb: ['buster']
         arch: ['aarch64']
+        exclude:
+          - ghc: '9.12.2'
+            deb: 'buster'
         include:
           # bookworm (debian 12)
           - ghc: '9.12.2'

--- a/9.12/bookworm/Dockerfile
+++ b/9.12/bookworm/Dockerfile
@@ -1,0 +1,134 @@
+FROM debian:bookworm
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=3.3.1
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.14.1.1
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.12.2
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]

--- a/9.12/bookworm/Dockerfile
+++ b/9.12/bookworm/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.12/slim-bookworm/Dockerfile
+++ b/9.12/slim-bookworm/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
 RUN apt-get update && \
@@ -129,6 +129,6 @@ RUN set -eux; \
     \
     "/opt/ghc/$GHC/bin/ghc" --version
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 
 CMD ["ghci"]

--- a/9.12/slim-bookworm/Dockerfile
+++ b/9.12/slim-bookworm/Dockerfile
@@ -1,0 +1,134 @@
+FROM debian:bookworm-slim
+
+ENV LANG C.UTF-8
+
+# common haskell + stack dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dpkg-dev \
+        git \
+        gcc \
+        gnupg \
+        g++ \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        netbase \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG STACK=3.3.1
+ARG STACK_RELEASE_KEY=C5705533DA4F78D8664B5DC0575159689BEFB442
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
+    stack --version;
+
+ARG CABAL_INSTALL=3.14.1.1
+ARG CABAL_INSTALL_RELEASE_KEY=EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
+    cabal --version
+
+ARG GHC=9.12.2
+ARG GHC_RELEASE_KEY=FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD
+
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
+    "/opt/ghc/$GHC/bin/ghc" --version
+
+ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
+
+CMD ["ghci"]


### PR DESCRIPTION
There's a question of what do do with all those buster images (since buster is long past the end of life).
For now I commented them out in CI config.
But I think we could even remove all of them from the repo. WDYT @develop7 ?

This PR aims to supersede https://github.com/haskell/docker-haskell/pull/145 