### PR TITLE
fix: reverting heredocs in Dockerfile template

### DIFF
--- a/9.10/bookworm/Dockerfile
+++ b/9.10/bookworm/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.10.3'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.10.3/ghc-9.10.3-aarch64-deb11-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='1ac63f04eac0ad551d45cbde38f27e0e3f43ceefd98833fae1fa3f2dbd042367'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.10.3/ghc-9.10.3-aarch64-deb11-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='1ac63f04eac0ad551d45cbde38f27e0e3f43ceefd98833fae1fa3f2dbd042367'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.10/bullseye/Dockerfile
+++ b/9.10/bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.10.3'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'
-            ;;
-        'x86_64')
-            GHC_SHA256='b6bbd3514e0cdb9db350812a003bb7c670c58d99779086fbe41092b019548924'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='b6bbd3514e0cdb9db350812a003bb7c670c58d99779086fbe41092b019548924'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.10/slim-bookworm/Dockerfile
+++ b/9.10/slim-bookworm/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.10.3'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.10.3/ghc-9.10.3-aarch64-deb11-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='1ac63f04eac0ad551d45cbde38f27e0e3f43ceefd98833fae1fa3f2dbd042367'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.10.3/ghc-9.10.3-aarch64-deb11-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='1ac63f04eac0ad551d45cbde38f27e0e3f43ceefd98833fae1fa3f2dbd042367'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.10/slim-bullseye/Dockerfile
+++ b/9.10/slim-bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.10.3'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'
-            ;;
-        'x86_64')
-            GHC_SHA256='b6bbd3514e0cdb9db350812a003bb7c670c58d99779086fbe41092b019548924'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='052789dfe7f6fba6dc3822de0da272e8a5bd358c37adae17d8e82cff39bc1008'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='b6bbd3514e0cdb9db350812a003bb7c670c58d99779086fbe41092b019548924'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.12/bookworm/Dockerfile
+++ b/9.12/bookworm/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.12.2'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'
-            ;;
-        'x86_64')
-            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.12/bullseye/Dockerfile
+++ b/9.12/bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.12.2'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.12.2/ghc-9.12.2-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='47d5faba492545b49b8dd49a79e64b4ef8eb4b1632d4ddc64355ce4e812eec75'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.12.2/ghc-9.12.2-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='47d5faba492545b49b8dd49a79e64b4ef8eb4b1632d4ddc64355ce4e812eec75'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.12/slim-bookworm/Dockerfile
+++ b/9.12/slim-bookworm/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bookworm-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb12.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='f763fb2af2bc1ff174b7361a7d51109a585954f87a0e14f86d144f3bce28f7a9'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='73a463306c771e18ca22c0a9469176ffab0138ec5925adb5364ef47174e1adc5'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.12.2'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'
-            ;;
-        'x86_64')
-            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb12-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='bee95bc91a621d8a2e9a9d86dac28ff839605e87316518dae12c779709bd58f1'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='447ec2fcc773ae9ebc3f39766c719641631274f9b765d7426a8cbe9241677c9f'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.12/slim-bullseye/Dockerfile
+++ b/9.12/slim-bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.12.2'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.12.2/ghc-9.12.2-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='47d5faba492545b49b8dd49a79e64b4ef8eb4b1632d4ddc64355ce4e812eec75'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.12.2/ghc-9.12.2-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='47d5faba492545b49b8dd49a79e64b4ef8eb4b1632d4ddc64355ce4e812eec75'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.4/bullseye/Dockerfile
+++ b/9.4/bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.4.8'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.4/slim-bullseye/Dockerfile
+++ b/9.4/slim-bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.4.8'
 ARG GHC_RELEASE_KEY='88B57FCF7DB53B4DB3BFA4B1588764FBE22D19C4'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.6.7'
 ARG GHC_RELEASE_KEY='8C961469C8FDC968718D6245AC7DE836C5DF907D'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='3cfa843687856de304a946dbe849a497c4fdad021f0275628b8ca7b55ccf8082'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.6.7/ghc-9.6.7-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='fc6a6247d1831745c67b27d6212f6911c35a933043f3b6851724e2e01484d077'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='3cfa843687856de304a946dbe849a497c4fdad021f0275628b8ca7b55ccf8082'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.6.7/ghc-9.6.7-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='fc6a6247d1831745c67b27d6212f6911c35a933043f3b6851724e2e01484d077'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,121 +22,115 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.6.7'
 ARG GHC_RELEASE_KEY='8C961469C8FDC968718D6245AC7DE836C5DF907D'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='3cfa843687856de304a946dbe849a497c4fdad021f0275628b8ca7b55ccf8082'
-            GHC_URL='https://downloads.haskell.org/~ghc/9.6.7/ghc-9.6.7-aarch64-deb10-linux.tar.xz'
-            ;;
-        'x86_64')
-            GHC_SHA256='fc6a6247d1831745c67b27d6212f6911c35a933043f3b6851724e2e01484d077'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='3cfa843687856de304a946dbe849a497c4fdad021f0275628b8ca7b55ccf8082'; \
+            GHC_URL='https://downloads.haskell.org/~ghc/9.6.7/ghc-9.6.7-aarch64-deb10-linux.tar.xz'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='fc6a6247d1831745c67b27d6212f6911c35a933043f3b6851724e2e01484d077'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.8/bullseye/Dockerfile
+++ b/9.8/bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.8.4'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'
-            ;;
-        'x86_64')
-            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/9.8/slim-bullseye/Dockerfile
+++ b/9.8/slim-bullseye/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:bullseye-slim
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,120 +22,114 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='3.3.1'
 ARG STACK_RELEASE_KEY='C5705533DA4F78D8664B5DC0575159689BEFB442'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'
-            ;;
-        'x86_64') 
-            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='bdd618ea5a9c921417727011f2ecd78987dffa5cee5e741108baf65a9b5b58ab'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='88d7e517342c125b0a098d9d578fe53e590618ae4b2427283a27408a1ebd06d8'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='3.14.1.1'
 ARG CABAL_INSTALL_RELEASE_KEY='EAF2A9A722C0C96F2B431CA511AAD8CEDEE0CAEF'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-deb11.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='5e8c47a055d5b744741039a7061ee43ec7d080d1251784e7a4cd836403e42523'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='41b85bb25fa654e4b79169014b9142fe696ff35e002e043caa0e52d65204ba8a'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='9.8.4'
 ARG GHC_RELEASE_KEY='FFEB7CE81E16A36B3E2DED6F2DE04D4E97DB64AD'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'
-            ;;
-        'x86_64')
-            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-deb11-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3'; \
+            ;; \
+        'x86_64') \
+            GHC_SHA256='af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -3,8 +3,7 @@ FROM {{ distro.image }}
 ENV LANG=C.UTF-8
 
 # common haskell + stack dependencies
-RUN <<EOT
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -23,123 +22,117 @@ RUN <<EOT
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-EOT
+
 
 ARG STACK='{{ _globals.stack.version }}'
 ARG STACK_RELEASE_KEY='{{ _globals.stack.release_key }}'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"
-    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256
-    case "$ARCH" in 
-        'aarch64') 
-            STACK_SHA256='{{ _globals.stack.sha256sum.aarch64 }}'
-            ;;
-        'x86_64') 
-            STACK_SHA256='{{ _globals.stack.sha256sum.x86_64 }}'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ;
-    esac
-    curl -sSL "$STACK_URL" -o stack.tar.gz
-    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check
-    
-    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc
-    GNUPGHOME="$(mktemp -d)"
-    export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"
-    gpg --batch --verify stack.tar.gz.asc stack.tar.gz
-    gpgconf --kill all
-    
-    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"
-    stack config set system-ghc --global true
-    stack config set install-ghc --global false
-    
-    rm -rf /tmp/*
-    
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz"; \
+    # sha256 from https://github.com/commercialhaskell/stack/releases/download/v${STACK}/stack-${STACK}-linux-$ARCH.tar.gz.sha256 \
+    case "$ARCH" in \
+        'aarch64') \
+            STACK_SHA256='{{ _globals.stack.sha256sum.aarch64 }}'; \
+            ;; \
+        'x86_64') \
+            STACK_SHA256='{{ _globals.stack.sha256sum.x86_64 }}'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" exit 1 ; \
+    esac; \
+    curl -sSL "$STACK_URL" -o stack.tar.gz; \
+    echo "$STACK_SHA256 stack.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSL "$STACK_URL.asc" -o stack.tar.gz.asc; \
+    GNUPGHOME="$(mktemp -d)"; \
+    export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$STACK_RELEASE_KEY"; \
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz; \
+    gpgconf --kill all; \
+    \
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 "stack-$STACK-linux-$ARCH/stack"; \
+    stack config set system-ghc --global true; \
+    stack config set install-ghc --global false; \
+    \
+    rm -rf /tmp/*; \
+    \
     stack --version;
-EOT
 
 ARG CABAL_INSTALL='{{ _globals.cabal_install.version }}'
 ARG CABAL_INSTALL_RELEASE_KEY='{{ _globals.cabal_install.release_key }}'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-{{ distro.abbr }}.tar.xz"
-    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"
-    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"
-    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            CABAL_INSTALL_SHA256='{{ cabal_install.sha256sum.aarch64 }}'
-            ;;
-        'x86_64')
-            CABAL_INSTALL_SHA256='{{ cabal_install.sha256sum.x86_64 }}'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;;
-    esac
-    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz
-    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check
-
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"
-    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"
-    gpg --batch --verify SHA256SUMS.sig SHA256SUMS
-    # confirm we are verifying SHA256SUMS that matches the release + sha256
-    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS
-    gpgconf --kill all;
-
-    tar -xf cabal-install.tar.gz -C /usr/local/bin
-
-    rm -rf /tmp/*
-
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    CABAL_INSTALL_TAR="cabal-install-$CABAL_INSTALL-$ARCH-linux-{{ distro.abbr }}.tar.xz"; \
+    CABAL_INSTALL_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/$CABAL_INSTALL_TAR"; \
+    CABAL_INSTALL_SHA256SUMS_URL="https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS"; \
+    # sha256 from https://downloads.haskell.org/~cabal/cabal-install-$CABAL_INSTALL/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            CABAL_INSTALL_SHA256='{{ cabal_install.sha256sum.aarch64 }}'; \
+            ;; \
+        'x86_64') \
+            CABAL_INSTALL_SHA256='{{ cabal_install.sha256sum.x86_64 }}'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'"; exit 1 ;; \
+    esac; \
+    curl -fSL "$CABAL_INSTALL_URL" -o cabal-install.tar.gz; \
+    echo "$CABAL_INSTALL_SHA256 cabal-install.tar.gz" | sha256sum --strict --check; \
+    \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL"; \
+    curl -sSLO "$CABAL_INSTALL_SHA256SUMS_URL.sig"; \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$CABAL_INSTALL_RELEASE_KEY"; \
+    gpg --batch --verify SHA256SUMS.sig SHA256SUMS; \
+    # confirm we are verifying SHA256SUMS that matches the release + sha256 \
+    grep "$CABAL_INSTALL_SHA256  $CABAL_INSTALL_TAR" SHA256SUMS; \
+    gpgconf --kill all; \
+    \
+    tar -xf cabal-install.tar.gz -C /usr/local/bin; \
+    \
+    rm -rf /tmp/*; \
+    \
     cabal --version
-EOT
 
 ARG GHC='{{ ghc.version }}'
 ARG GHC_RELEASE_KEY='{{ ghc.release_key }}'
 
-RUN <<EOT
-    set -eux
-    cd /tmp
-    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"
-    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-{{ distro.abbr }}-linux.tar.xz"
-    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS
-    case "$ARCH" in
-        'aarch64')
-            GHC_SHA256='{{ ghc.sha256sum.aarch64 }}'
+RUN set -eux; \
+    cd /tmp; \
+    ARCH="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)"; \
+    GHC_URL="https://downloads.haskell.org/~ghc/$GHC/ghc-$GHC-$ARCH-{{ distro.abbr }}-linux.tar.xz"; \
+    # sha256 from https://downloads.haskell.org/~ghc/$GHC/SHA256SUMS \
+    case "$ARCH" in \
+        'aarch64') \
+            GHC_SHA256='{{ ghc.sha256sum.aarch64 }}'; \
 {% if overrides.ghc.aarch64.url %}
-            GHC_URL='{{ overrides.ghc.aarch64.url }}'
+            GHC_URL='{{ overrides.ghc.aarch64.url }}'; \
 {% endif %}
-            ;;
-        'x86_64')
-            GHC_SHA256='{{ ghc.sha256sum.x86_64 }}'
-            ;;
-        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;;
-    esac
-    curl -sSL "$GHC_URL" -o ghc.tar.xz
-    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check
-
-    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
-    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig
-    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz
-    gpgconf --kill all
-
-    tar xf ghc.tar.xz
-    cd "ghc-$GHC-$ARCH-unknown-linux"
-    ./configure --prefix "/opt/ghc/$GHC"
-    make install
-
-    rm -rf /tmp/*
-
+            ;; \
+        'x86_64') \
+            GHC_SHA256='{{ ghc.sha256sum.x86_64 }}'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture '$ARCH'" ; exit 1 ;; \
+    esac; \
+    curl -sSL "$GHC_URL" -o ghc.tar.xz; \
+    echo "$GHC_SHA256 ghc.tar.xz" | sha256sum --strict --check; \
+    \
+    GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+    curl -sSL "$GHC_URL.sig" -o ghc.tar.xz.sig; \
+    gpg --batch --keyserver keyserver.ubuntu.com --receive-keys "$GHC_RELEASE_KEY"; \
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz; \
+    gpgconf --kill all; \
+    \
+    tar xf ghc.tar.xz; \
+    cd "ghc-$GHC-$ARCH-unknown-linux"; \
+    ./configure --prefix "/opt/ghc/$GHC"; \
+    make install; \
+    \
+    rm -rf /tmp/*; \
+    \
     "/opt/ghc/$GHC/bin/ghc" --version
-EOT
 
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${GHC}/bin:$PATH
 


### PR DESCRIPTION
It appears per https://github.com/docker-library/official-images/pull/20186/#issuecomment-3470673874 heredocs are not supported in `Dockerfile`s submitted to docker-library