### PR TITLE
fix: drop pinned base image digests from FROM lines

### DIFF
--- a/9.0/buster/Dockerfile
+++ b/9.0/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster@sha256:c9285bcb198c0ae171bfc350a4af94ddfda547c4e4d2900a92c280232319341e
+FROM buildpack-deps:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.0/slim-buster/Dockerfile
+++ b/9.0/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.10/bookworm.ncl
+++ b/9.10/bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm",
-    digest = "sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168",
   },
   ghc = {
     version = "9.10.3",

--- a/9.10/bookworm/Dockerfile
+++ b/9.10/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm@sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168
+FROM debian:bookworm
 
 ENV LANG=C.UTF-8
 

--- a/9.10/bullseye.ncl
+++ b/9.10/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = {
     version = "9.10.3",

--- a/9.10/bullseye/Dockerfile
+++ b/9.10/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.10/buster/Dockerfile
+++ b/9.10/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster@sha256:58ce6f1271ae1c8a2006ff7d3e54e9874d839f573d8009c20154ad0f2fb0a225
+FROM debian:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.10/slim-bookworm.ncl
+++ b/9.10/slim-bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm-slim",
-    digest = "sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df",
   },
   ghc = {
     version = "9.10.3",

--- a/9.10/slim-bookworm/Dockerfile
+++ b/9.10/slim-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+FROM debian:bookworm-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.10/slim-bullseye.ncl
+++ b/9.10/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = {
     version = "9.10.3",

--- a/9.10/slim-bullseye/Dockerfile
+++ b/9.10/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.10/slim-buster/Dockerfile
+++ b/9.10/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.12/bookworm.ncl
+++ b/9.12/bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm",
-    digest = "sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168",
   },
   ghc = {
     version = "9.12.4",

--- a/9.12/bookworm/Dockerfile
+++ b/9.12/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm@sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168
+FROM debian:bookworm
 
 ENV LANG=C.UTF-8
 

--- a/9.12/bullseye.ncl
+++ b/9.12/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = {
     version = "9.12.4",

--- a/9.12/bullseye/Dockerfile
+++ b/9.12/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.12/slim-bookworm.ncl
+++ b/9.12/slim-bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm-slim",
-    digest = "sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df",
   },
   ghc = {
     version = "9.12.4",

--- a/9.12/slim-bookworm/Dockerfile
+++ b/9.12/slim-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+FROM debian:bookworm-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.12/slim-bullseye.ncl
+++ b/9.12/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = {
     version = "9.12.4",

--- a/9.12/slim-bullseye/Dockerfile
+++ b/9.12/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.14/bookworm.ncl
+++ b/9.14/bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm",
-    digest = "sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168",
   },
   ghc = {
     version = "9.14.1",

--- a/9.14/bookworm/Dockerfile
+++ b/9.14/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm@sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168
+FROM debian:bookworm
 
 ENV LANG=C.UTF-8
 

--- a/9.14/bullseye.ncl
+++ b/9.14/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = {
     version = "9.14.1",

--- a/9.14/bullseye/Dockerfile
+++ b/9.14/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.14/slim-bookworm.ncl
+++ b/9.14/slim-bookworm.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bookworm",
     abbr = "deb12",
     image = "debian:bookworm-slim",
-    digest = "sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df",
   },
   ghc = {
     version = "9.14.1",

--- a/9.14/slim-bookworm/Dockerfile
+++ b/9.14/slim-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+FROM debian:bookworm-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.14/slim-bullseye.ncl
+++ b/9.14/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = {
     version = "9.14.1",

--- a/9.14/slim-bullseye/Dockerfile
+++ b/9.14/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.2/buster/Dockerfile
+++ b/9.2/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster@sha256:c9285bcb198c0ae171bfc350a4af94ddfda547c4e4d2900a92c280232319341e
+FROM buildpack-deps:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.2/slim-buster/Dockerfile
+++ b/9.2/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.4/bullseye.ncl
+++ b/9.4/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.4/bullseye/Dockerfile
+++ b/9.4/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.4/buster/Dockerfile
+++ b/9.4/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster@sha256:c9285bcb198c0ae171bfc350a4af94ddfda547c4e4d2900a92c280232319341e
+FROM buildpack-deps:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.4/slim-bullseye.ncl
+++ b/9.4/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.4/slim-bullseye/Dockerfile
+++ b/9.4/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.4/slim-buster/Dockerfile
+++ b/9.4/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.6/bullseye.ncl
+++ b/9.6/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.6/buster/Dockerfile
+++ b/9.6/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster@sha256:c9285bcb198c0ae171bfc350a4af94ddfda547c4e4d2900a92c280232319341e
+FROM buildpack-deps:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.6/slim-bullseye.ncl
+++ b/9.6/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.6/slim-bullseye/Dockerfile
+++ b/9.6/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.6/slim-buster/Dockerfile
+++ b/9.6/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.8/bullseye.ncl
+++ b/9.8/bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye",
-    digest = "sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.8/bullseye/Dockerfile
+++ b/9.8/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bullseye
 
 ENV LANG=C.UTF-8
 

--- a/9.8/buster/Dockerfile
+++ b/9.8/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster@sha256:c9285bcb198c0ae171bfc350a4af94ddfda547c4e4d2900a92c280232319341e
+FROM buildpack-deps:buster
 
 ENV LANG=C.UTF-8
 

--- a/9.8/slim-bullseye.ncl
+++ b/9.8/slim-bullseye.ncl
@@ -6,7 +6,6 @@ globals
     codename = "bullseye",
     abbr = "deb11",
     image = "debian:bullseye-slim",
-    digest = "sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84",
   },
   ghc = import "_ghc.ncl",
   cabal_install = import "_cabal-install.ncl",

--- a/9.8/slim-bullseye/Dockerfile
+++ b/9.8/slim-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8
 

--- a/9.8/slim-buster/Dockerfile
+++ b/9.8/slim-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc
+FROM debian:buster-slim
 
 ENV LANG=C.UTF-8
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "description": "official-images does not accept digest-pinned FROM lines (https://github.com/docker-library/official-images/pull/21812)",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": false
+    }
   ]
 }

--- a/template/Dockerfile.ncl
+++ b/template/Dockerfile.ncl
@@ -9,16 +9,8 @@ let render = fun cfg =>
     else
       ""
   in
-  let digest_part =
-    if std.record.has_field "digest" distro then
-      "@%{distro.digest}"
-    else
-      ""
-  in
-  let from_ref = "%{distro.image}%{digest_part}"
-  in
   m%"
-FROM %{from_ref}
+FROM %{distro.image}
 
 ENV LANG=C.UTF-8
 

--- a/template/schema.ncl
+++ b/template/schema.ncl
@@ -54,10 +54,6 @@ in
         image
           | String
           | doc "Docker image identifier",
-        digest
-          | String
-          | optional
-          | doc "Image digest, e.g. sha256:ed4fcc40bb1162b6d2d32e7bec15044d13963779abbe63f67f1cd62b06220519",
       },
     ghc
       | {


### PR DESCRIPTION
official-images repo doesn't accept digest-pinned FROM lines - bashbrew resolves the parent image from the tag and rebuilds haskell images whenever the base image is rebuilt, which pinning defeats. See https://github.com/docker-library/official-images/pull/21812

- remove the digest field from the Nickel schema, template, and all variant data files, and regenerate the Dockerfiles
- strip digests from the hand maintained buster/slim-buster Dockerfiles
- disable Renovate's pinDigests for Dockerfiles so they don't come back