### PR TITLE
fix(ci): generate_dockerfiles.nu: path parse returns record, not table

### DIFF
--- a/generate_dockerfiles.nu
+++ b/generate_dockerfiles.nu
@@ -43,7 +43,7 @@ def main [
 # `nickel` errors abort the script via the surrounding shell, so a
 # non-zero exit is the error signal.
 def gen-file [template_dir: path]: path -> string  {
-  let parts: table = $in | path parse
+  let parts: record = $in | path parse
   let template: path = $template_dir | path join Dockerfile.ncl
   let schema: path = $template_dir | path join schema.ncl
   let outfile: path = [$parts.parent $parts.stem Dockerfile] | path join


### PR DESCRIPTION
The `generate` job (`.github/workflows/generator.yml`) fails on every PR with:

```
generate_dockerfiles.nu:17:22  Type mismatch
  let parts: table = $in | path parse
                    ^^^^^^^^ expected table, found record
```

`path parse` returns `record<parent,stem,extension>`, not `table`. Current nushell (installed via `nixpkgs#nushell`) rejects the `: table` annotation at **parse time**, so the script exits 1 before generating anything.

`generator.yml` runs on `pull_request: {}`, so this surfaced on #213 but is unrelated to it — it breaks every PR.

**Fix:** `table` → `record` on line 17. Verified locally: all 24 Dockerfiles generate, `git diff --exit-code` clean.