### PR TITLE
chore(renovate): ignore generated Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:best-practices"
   ],
+  "ignorePaths": [
+    "**/Dockerfile"
+  ],
   "packageRules": [
     {
       "description": "official-images does not accept digest-pinned FROM lines (https://github.com/docker-library/official-images/pull/21812)",


### PR DESCRIPTION
The `*/Dockerfile` files are generated from `.ncl` sources by `generate_dockerfiles.nu` (see `.github/workflows/generator.yml`). Renovate was editing them directly — e.g. rewriting every `debian:bookworm` to `debian:trixie` in #193 — which is:

- **pointless** — regenerated on the next generator run, so the change never sticks
- **wrong** — the codename (`bookworm`/`bullseye`) is a deliberate per-image choice, not a version pin to bump

Add `**/Dockerfile` to `ignorePaths` so the `dockerfile` manager skips generated output. The manager does not scan `.ncl`, so nothing replaces it; base-image changes stay a human decision made in the `.ncl` sources.

Verified: `renovate.json` parses, and the pattern matches all `*/Dockerfile` paths but not the `.ncl` sources.